### PR TITLE
Kim073-BCMOE-LocationsData-Add-Missing-OpenXml-Dll

### DIFF
--- a/src/Reports.PluginPackager/Context.cs
+++ b/src/Reports.PluginPackager/Context.cs
@@ -27,7 +27,6 @@ namespace Reports.PluginPackager
             "NodaTime.*",
             "ComponentFactory.*",
             "PerpetuumSoft.*",
-            "DocumentFormat.OpenXml.dll",
             "itextsharp.dll",
             "NewtonSoft.*",
         };


### PR DESCRIPTION
Excel xlsx output format requires DocumentFormat.OpenXml.dll included in report package