### PR TITLE
Kim082-Fail-When-Out-Of-Date-ReportDefinition-Wsc-12MPP-Report

### DIFF
--- a/src/Reports.Common/Common.cs
+++ b/src/Reports.Common/Common.cs
@@ -59,6 +59,23 @@ namespace Reports
             return _WaterYearMonth;
         }
 
+        public void CheckReportDefinitionVersion(string requiredVersion)
+        {
+            bool containsVersionKey = _RunReportRequest.ReportDefinitionMetadata.ContainsKey("Version");
+
+            string version = (containsVersionKey) ? _RunReportRequest.ReportDefinitionMetadata["Version"] : "1";
+
+            if (version != requiredVersion)
+            {
+                string msg = string.Format(
+                    "Exception due to an incompatible version of report definition: the report definition is '{0}' " +
+                    "but this report requires '{1}', check the value of the " +
+                    "System Configuration Tool setting ReportPluginConfig-{2}",
+                    version, requiredVersion, _DllName);
+                throw new Exception(msg);
+            }
+        }
+
         public TimeSpan GetReportTimeSpanOffset()
         {
             if ((_RunReportRequest.Inputs != null) && (_RunReportRequest.Inputs.TimeSeriesInputs.Count > 0))

--- a/src/Reports/TwelveMonthDailyMean/ReportSpecificTableBuilder.cs
+++ b/src/Reports/TwelveMonthDailyMean/ReportSpecificTableBuilder.cs
@@ -20,11 +20,12 @@ namespace TwelveMonthDailyMeanNamespace
         {
             try
             {
+                Common common = (Common)dataSet.Tables["RunReportRequest"].Rows[0]["CommonLibrary"];
+                common.CheckReportDefinitionVersion("2");
+
                 dataSet.Tables["SourceDataStageWorkingOrDischargeWorking"].TableName = "SourceData";
                 dataSet.Tables["SourceDataStageWorkingOrDischargeWorkingLocation"].TableName = "SourceDataLocation";
                 dataSet.Tables["SourceDataStageWorkingOrDischargeWorkingLocationExtendedAttributes"].TableName = "SourceDataLocationExtendedAttributes";
-
-                Common common = (Common)dataSet.Tables["RunReportRequest"].Rows[0]["CommonLibrary"];
 
                 DataTable settingsTable = dataSet.Tables["ReportSettings"];
                 settingsTable.Columns.Add("ReportTitle", typeof(string));

--- a/src/Reports/TwelveMonthDailyMean/TwelveMonthDailyMean.json
+++ b/src/Reports/TwelveMonthDailyMean/TwelveMonthDailyMean.json
@@ -1,5 +1,5 @@
 ﻿{
-  "Name": "Twelve Month Daily Mean",
+  "Name": "TwelveMonthDailyMean",
   "DefaultTimeRange": 
   {
     "Type": "LatestComplete",
@@ -38,6 +38,7 @@
   ],
   "Metadata":
     {
+	  "Version": "2",
 	  "GradeMarker  -2" : "",
 	  "GradeMarker  -1" : "",
 	  "GradeMarker   0" : "",


### PR DESCRIPTION
Add hidden parameter "Version" set to "2" in report definition's metadata section
If report run and report definition is not version "2" then throw exception