### PR TITLE
AQ-26856 Exclude Microsoft Dlls From Report Package

### DIFF
--- a/src/Reports.PluginPackager/Context.cs
+++ b/src/Reports.PluginPackager/Context.cs
@@ -28,7 +28,8 @@ namespace Reports.PluginPackager
             "ComponentFactory.*",
             "PerpetuumSoft.*",
             "NewtonSoft.*",
-            "System.*"
+            "System.*",
+            "Microsoft.*"
         };
     }
 }


### PR DESCRIPTION
These dlls are already installed with the Server and
can be excluded to keep the report package file size
smaller.