### PR TITLE
Kim102-WSC-Fix-Benchmark-History-Diff-Values

### DIFF
--- a/src/Reports/BenchmarkHistory/ReportSpecificFunctions.cs
+++ b/src/Reports/BenchmarkHistory/ReportSpecificFunctions.cs
@@ -2,10 +2,8 @@
 using System.Data;
 using System.Reflection;
 using ReportPluginFramework;
-using ReportPluginFramework.ReportData;
-using ReportPluginFramework.ReportData.TimeSeriesComputedStatistics;
-using ReportPluginFramework.ReportData.TimeSeriesData;
-using ReportPluginFramework.ReportData.TimeSeriesDescription;
+using Server.Services.PublishService.ServiceModel.Dtos.FieldVisit;
+using Server.Services.PublishService.ServiceModel.Dtos;
 using System.Collections.Generic;
 
 namespace BenchmarkHistoryNamespace
@@ -19,6 +17,16 @@ namespace BenchmarkHistoryNamespace
             if (interval.End.HasValue && (start > interval.End.Value)) return false;
             if (interval.Start.HasValue && end.HasValue && (end < interval.Start.Value)) return false;
             return true;
+        }
+        public static double calculateDifference(LevelSurveyMeasurement lsm, List<ReferencePointPeriod> refPointHistory)
+        {
+            double level = lsm.MeasuredElevation.Numeric.Value;
+            foreach (ReferencePointPeriod period in refPointHistory)
+            {
+                if (lsm.MeasurementTime >= period.ValidFrom)
+                    return level - period.Elevation;
+            }
+            return double.NaN;
         }
     }
 }

--- a/src/Reports/BenchmarkHistory/ReportSpecificTableBuilder.cs
+++ b/src/Reports/BenchmarkHistory/ReportSpecificTableBuilder.cs
@@ -94,7 +94,7 @@ namespace BenchmarkHistoryNamespace
 
                 if (refPoints.Count == 0) return;
 
-                Dictionary<Guid, double> refPointElevations = new Dictionary<Guid, double>();
+                Dictionary<Guid, List<ReferencePointPeriod>> refPointHistories = new Dictionary<Guid, List<ReferencePointPeriod>>();
                 Dictionary<Guid, int> refPointNumbers = new Dictionary<Guid, int>();
 
                 for (int i = 0; i < refPoints.Count; i++)
@@ -127,7 +127,8 @@ namespace BenchmarkHistoryNamespace
                     double elevation = refPointPeriods[refPointPeriods.Count - 1].Elevation;
                     row["Elevation"] = Common.FormatDoubleValue(elevation, formatFixed, formatPrecision, "");
 
-                    refPointElevations[refPoint.UniqueId] = elevation;
+                    refPointPeriods.Reverse();
+                    refPointHistories[refPoint.UniqueId] = refPointPeriods;
 
                     benchmarks.Rows.Add(row);
                 }
@@ -201,7 +202,7 @@ namespace BenchmarkHistoryNamespace
                         int thePosition = (int)(number % groupSizeLimit);
 
                         double level = lsm.MeasuredElevation.Numeric.Value;
-                        double correction = level - refPointElevations[id];
+                        double correction = ReportSpecificFunctions.calculateDifference(lsm, refPointHistories[id]);
 
                         DataRow row = dataSet.Tables["BenchmarkHistory"].Rows[fieldVisitFirstRow + theGroupNumber];
 


### PR DESCRIPTION
Change calculation of values for diff column to be like 3.x calculation
which requires use of historical benchmark elevation when calculating the diff value