### PR TITLE
AQ-26010 Include Microsoft.Win32.Registry.dll in plugin package

### DIFF
--- a/src/Reports.PluginPackager/Context.cs
+++ b/src/Reports.PluginPackager/Context.cs
@@ -12,6 +12,8 @@ namespace Reports.PluginPackager
 
         public List<string> ForceInclude { get; } = new List<string>
         {
+            "Microsoft.Win32.Primitives.dll",
+            "Microsoft.Win32.Registry.dll",
             "PerpetuumSoft.Reporting.Export.Csv.dll",
             "PerpetuumSoft.Reporting.Export.OpenXML.dll"
         };


### PR DESCRIPTION
Required for R-Based reports and isn't included in the AQTS server install.