### PR TITLE
AT-596 replaced GetTempFileName with GetRandomFileName

### DIFF
--- a/src/Reports.ReportPluginBase/ReportPluginBase.cs
+++ b/src/Reports.ReportPluginBase/ReportPluginBase.cs
@@ -18,7 +18,7 @@ namespace Reports
     public abstract class ReportPluginBase
     {
         private static ServiceStack.Logging.ILog Log = ServiceStack.Logging.LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        public Assembly _Assembly = Assembly.GetExecutingAssembly();
+        private Assembly _Assembly = Assembly.GetExecutingAssembly();
 
         public virtual FileReportOutput GenerateReport(RunFileReportRequest request)
         {
@@ -30,7 +30,7 @@ namespace Reports
             return fileReportOutput;
         }
 
-        public string GenerateReportIntoFile(RunFileReportRequest request)
+        private string GenerateReportIntoFile(RunFileReportRequest request)
         {
             Thread.CurrentThread.CurrentCulture.NumberFormat = CultureInfo.InvariantCulture.NumberFormat;
 
@@ -65,19 +65,10 @@ namespace Reports
             string outputFormat = request.OutputFormat;
             Log.DebugFormat("GenerateReport after RenderDocument, document name is {0}, page count is {1}, outputFormat is {2}",
                 document.Name, document.Pages.Count, outputFormat);
-
-            string tempFileName = Path.GetTempFileName();
+            
+            string tempFolderPath = Path.GetTempPath();
+            string tempFileName = Path.Combine(tempFolderPath, Path.GetRandomFileName());
             string outputFileName = Path.ChangeExtension(tempFileName, outputFormat);
-            try
-            {
-                File.Delete(tempFileName);
-            }
-            catch { }
-            try
-            {
-                File.Delete(outputFileName);
-            }
-            catch { }
 
             Log.DebugFormat("GenerateReport - the name of file for export report to write to is set to {0}", outputFileName);
 

--- a/src/Reports.ReportPluginBase/ReportPluginBase.cs
+++ b/src/Reports.ReportPluginBase/ReportPluginBase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Data;
+﻿using System.Data;
 using System.Reflection;
 using ReportPluginFramework;
 using PerpetuumSoft.Reporting.Components;

--- a/src/Reports.ReportPluginBase/ReportPluginBase.cs
+++ b/src/Reports.ReportPluginBase/ReportPluginBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 using System.Reflection;
 using ReportPluginFramework;
 using PerpetuumSoft.Reporting.Components;
@@ -67,6 +68,12 @@ namespace Reports
                 document.Name, document.Pages.Count, outputFormat);
             
             string tempFolderPath = Path.GetTempPath();
+
+            if (!Directory.Exists(tempFolderPath))
+            {
+                throw new DirectoryNotFoundException("Temp folder directory does not exist.");
+            }
+            
             string tempFileName = Path.Combine(tempFolderPath, Path.GetRandomFileName());
             string outputFileName = Path.ChangeExtension(tempFileName, outputFormat);
 


### PR DESCRIPTION
@AquaticInformatics/artemis switched to use GetRandomFileName instead as it doesn't create a new temp file like GetTempFileName. there is also a lower chance of collision as GetRandomFileName generates an 11 (https://www.dotnetperls.com/path-getrandomfilename) character file name compared to GetTempFileName that has a ~65K limit (https://learn.microsoft.com/en-us/dotnet/api/system.io.path.gettempfilename?view=net-8.0#remarks) on the number of temp files it can created. GetRandomFileName has a lower change of collision due to the higher file name character count (https://stackoverflow.com/questions/21684696/will-path-getrandomfilename-generate-a-unique-filename-every-time/21684837#21684837) as well as not creating the file which is what the GetTempFileName function errored out with.